### PR TITLE
fix #12: Compatible with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -148,8 +148,11 @@ hr {
    </div>
 <div id="pageBody">
 
-<p><b>2.7.2</b> -- To Be Determined</p>
+<p><b>2.8.0</b> -- To Be Determined</p>
 <ul>
+    <li>Requires Openfire 4.4.0.</li>
+    <li>Requires Java 11 or later</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-userImportExport-plugin/issues/12'>#12</a>] - Fixes Openfire 5.0.0 compatibility issue.</li>
 </ul>
 
 <p><b>2.7.1</b> -- November 21, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,8 +7,9 @@
    <description>Enables import and export of user data</description>
    <author>Ryan Graham</author>
    <version>${project.version}</version>
-   <date>2023-11-21</date>
-   <minServerVersion>4.3.0</minServerVersion>
+   <date>2025-06-23</date>
+   <minServerVersion>4.4.0</minServerVersion>
+   <minJavaVersion>11</minJavaVersion>
 
    <adminconsole>
       <tab id="tab-users">

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.4.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>userImportExport</artifactId>
-    <version>2.7.2-SNAPSHOT</version>
+    <version>2.8.0-SNAPSHOT</version>
     <name>UserImportExport Plugin</name>
     <description>Enables import and export of user data</description>
 
@@ -64,6 +64,11 @@
             <groupId>msv</groupId>
             <artifactId>xsdlib</artifactId>
             <version>${msv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/web/export-file.jsp
+++ b/src/web/export-file.jsp
@@ -7,7 +7,7 @@
     boolean xep227Support = ParamUtils.getBooleanParameter(request, "xep227support", false);
 
     response.setHeader("Content-Disposition","attachment;filename="+fileName+".xml");
-    ImportExportPlugin plugin = (ImportExportPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("userimportexport");
+    ImportExportPlugin plugin = (ImportExportPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("User Import Export").orElseThrow();
     byte[] content = plugin.exportUsersToByteArray(xep227Support);
     OutputStream os = response.getOutputStream();
     os.write(content);

--- a/src/web/export-user-data.jsp
+++ b/src/web/export-user-data.jsp
@@ -16,7 +16,7 @@
     boolean xep227Support = ParamUtils.getBooleanParameter(request, "xep227support", false);
     
     ImportExportPlugin plugin = (ImportExportPlugin)XMPPServer.getInstance().getPluginManager(
-            ).getPlugin("userimportexport");
+            ).getPluginByName("User Import Export").orElseThrow();
 
     String exportText = "";
     

--- a/src/web/import-user-data.jsp
+++ b/src/web/import-user-data.jsp
@@ -13,7 +13,7 @@
     boolean importUsers = request.getParameter("importUsers") != null;
     boolean xep227Support = request.getParameter("xep227support") != null;
    
-    ImportExportPlugin plugin = (ImportExportPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("userimportexport");
+    ImportExportPlugin plugin = (ImportExportPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("User Import Export").orElseThrow();
     List<String> duplicateUsers = new ArrayList<String>();
    
     Map<String, String> errors = new HashMap<String, String>();


### PR DESCRIPTION
This replaces usage of Openfire API that was dropped in 5.0.0 with API that was introduced in 4.4.0. Also, a third-party library that no longer ships with Openfire is now added as a direct dependency of this plugin.

As a result, the plugin should now be compatible with Openfire 4.4.0 and later (including 5.0.0).